### PR TITLE
Update Links to Mujoco License and Downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ MuJoCo binaries and obtain license key.
 ## Obtaining the binaries and license key
 
 1. Obtain a 30-day free trial on the MuJoCo website:
-   https://www.roboti.us/trybuy.html. The license key will arrive in
+   https://www.roboti.us/license.html. The license key will arrive in
    an email with your username and password.
 2. Download the MuJoCo version 1.31 binaries for
-   [Linux](https://www.roboti.us/active/mjpro131_linux.zip),
-   [OSX](https://www.roboti.us/active/mjpro131_osx.zip), or
-   [Windows](https://www.roboti.us/active/mjpro131_windows.zip).
+   [Linux](https://www.roboti.us/download/mjpro131_linux.zip),
+   [OSX](https://www.roboti.us/download/mjpro131_osx.zip), 
+   [Windows32](https://www.roboti.us/download/mjpro131_win32.zip), or
+   [Windows64](https://www.roboti.us/download/mjpro131_win64.zip).
 3. Download your license key (the `mjkey.txt` file from your email)
    and unzip the downloaded mjpro bundle.
 4. Place these in `~/.mujoco/mjkey.txt` and `~/.mujoco/mjpro131`. You


### PR DESCRIPTION
Links to the Mujoco License and Downloads pages were broken, updating them to the latest.
