### PR TITLE
Add a joint_adr method.

### DIFF
--- a/mujoco_py/mjconstants.py
+++ b/mujoco_py/mjconstants.py
@@ -5,3 +5,9 @@ MOUSE_MOVE_H = 4
 MOUSE_ZOOM = 5
 
 mjOBJ_BODY = 1
+mjOBJ_JOINT = 2
+
+mjJNT_FREE  = 0
+mjJNT_BALL  = 1
+mjJNT_SLIDE = 2
+mjJNT_HINGE = 3

--- a/mujoco_py/mjcore.py
+++ b/mujoco_py/mjcore.py
@@ -92,6 +92,22 @@ class MjModel(MjModelWrapper):
         return [ctypes.string_at(start_addr + int(inc))
                 for inc in self.name_jntadr.flatten()]
 
+    def joint_adr(self, joint_name):
+        """Return (qposadr, qveladr, dof) for the given joint name.
+
+        If dof is 4 or 7, then the last 4 degrees of freedom in qpos represent a
+        unit quaternion."""
+        jntadr = mjlib.mj_name2id(self.ptr, C.mjOBJ_JOINT, joint_name)
+        assert(jntadr >= 0)
+        dofmap = {C.mjJNT_FREE:  7,
+                  C.mjJNT_BALL:  4,
+                  C.mjJNT_SLIDE: 1,
+                  C.mjJNT_HINGE: 1}
+        qposadr = self.jnt_qposadr[jntadr][0]
+        qveladr = self.jnt_dofadr[jntadr][0]
+        dof     = dofmap[self.jnt_type[jntadr][0]]
+        return (qposadr, qveladr, dof)
+
     @property
     def geom_names(self):
         start_addr = ctypes.addressof(self.names.contents)

--- a/mujoco_py/mjlib.py
+++ b/mujoco_py/mjlib.py
@@ -162,8 +162,8 @@ mjlib.mj_deleteData.restype = None
 #mjlib.mj_jacSite.restype = None
 #mjlib.mj_jacPointAxis.argtypes = [POINTER(MJMODEL), POINTER(MJDATA), POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_int]
 #mjlib.mj_jacPointAxis.restype = None
-#mjlib.mj_name2id.argtypes = [POINTER(MJMODEL), mjtObj, String]
-#mjlib.mj_name2id.restype = c_int
+mjlib.mj_name2id.argtypes = [POINTER(MJMODEL), c_int, String]  # The middle term is a mjtObj (an enum) in C.
+mjlib.mj_name2id.restype = c_int
 #mjlib.mj_id2name.argtypes = [POINTER(MJMODEL), mjtObj, c_int]
 #mjlib.    mj_id2name.restype = ReturnString
 #mjlib.else:


### PR DESCRIPTION
This makes it possible to look up addresses in the `qpos` and `qvel` arrays based on the name of a joint.