### PR TITLE
fix platname_targdir.py for windows

### DIFF
--- a/mujoco_py/platname_targdir.py
+++ b/mujoco_py/platname_targdir.py
@@ -3,7 +3,7 @@ if sys.platform.startswith("darwin"):
     platname = "osx"
 elif sys.platform.startswith("linux"):
     platname = "linux"
-elif sys.platform.startswith("windows"):
+elif sys.platform.startswith("win"):
     platname = "win"
 targdir = "mujoco_%s"%platname
 


### PR DESCRIPTION
sys.platform is just "win" for windows (see https://docs.python.org/3/library/sys.html#sys.platform), therefore the code fails resulting in the exception "NameError: name 'platname' is not defined".  the proposed change should work for all versions of windows