### PR TITLE
windows support

### DIFF
--- a/mujoco_py/mjlib.py
+++ b/mujoco_py/mjlib.py
@@ -11,7 +11,7 @@ if sys.platform.startswith("darwin"):
 elif sys.platform.startswith("linux"):
     libfile = os.path.join(path_prefix, "bin/libmujoco131.so")
 elif sys.platform.startswith("win"):
-    libfile = os.path.join(path_prefix, "bin/mujoco131.lib")
+    libfile = os.path.join(path_prefix, "bin/mujoco131.dll")
 else:
     raise RuntimeError("Unrecognized platform %s" % sys.platform)
 

--- a/mujoco_py/mjviewer.py
+++ b/mujoco_py/mjviewer.py
@@ -324,9 +324,9 @@ class MjViewer(object):
         glfw.make_context_current(self.window)
         glfw.destroy_window(self.window)
 
-        if gl.glIsFramebuffer(self._fbo):
+        if gl.glIsFramebuffer and gl.glIsFramebuffer(self._fbo):
             gl.glDeleteFramebuffers(int(self._fbo))
-        if gl.glIsRenderbuffer(self._rbo):
+        if gl.glIsRenderbuffer and gl.glIsRenderbuffer(self._rbo):
             gl.glDeleteRenderbuffers(1, int(self._rbo))
 
         mjlib.mjr_freeContext(byref(self.con))

--- a/mujoco_py/platname_targdir.py
+++ b/mujoco_py/platname_targdir.py
@@ -3,7 +3,7 @@ if sys.platform.startswith("darwin"):
     platname = "osx"
 elif sys.platform.startswith("linux"):
     platname = "linux"
-elif sys.platform.startswith("windows"):
+elif sys.platform.startswith("win"):
     platname = "win"
 targdir = "mujoco_%s"%platname
 


### PR DESCRIPTION
mujoco_py/platname_targdir.py: 
   sys.platform is "win32" for windows, not "windows"
mujoco_py/mjlib.py: 
   libfile needs to be ".dll" instead of ".lib"
mujoco_py/mjviewer.py: 
   gl.glIsFramebuffer and gl.glIsRenderbuffer can be unavailable and need to be checked before calling
