### PR TITLE
Add environment variable to force CPU

### DIFF
--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -41,7 +41,7 @@ The easy solution is to `import mujoco_py` _before_ `import glfw`.
     if sys.platform == 'darwin':
         Builder = MacExtensionBuilder
     elif sys.platform == 'linux':
-        if exists('/usr/local/nvidia/lib64'):
+        if exists('/usr/local/nvidia/lib64') and os.getenv('MUJOCO_PY_FORCE_CPU') is None:
             Builder = LinuxGPUExtensionBuilder
         else:
             Builder = LinuxCPUExtensionBuilder

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (1, 50, 1, 1)
+version_info = (1, 50, 1, 2)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 


### PR DESCRIPTION
If `MUJOCO_PY_FORCE_CPU` is set, always use CPU over GPU even if a NVIDIA GPU is available.