### PR TITLE
Add libGL to linux-cpu libraries

### DIFF
--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -161,7 +161,7 @@ class LinuxCPUExtensionBuilder(MujocoExtensionBuilder):
 
         self.extension.sources.append(
             join(self.CYMJ_DIR_PATH, "gl", "osmesashim.c"))
-        self.extension.libraries.extend(['glewosmesa', 'OSMesa'])
+        self.extension.libraries.extend(['glewosmesa', 'OSMesa', 'GL'])
         self.extension.runtime_library_dirs = [join(mjpro_path, 'bin')]
 
 


### PR DESCRIPTION
Fixes build on Fedora, strangely enough.  For some reason the osmesa/glew/glfw isn't enough on Fedora, but work on debian/ubuntu.

Fixes #60 