### PR TITLE
Add substep callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ tmp*
 cymj.c
 **/.git
 .eggs/
+*.c
+*.so

--- a/examples/substep_callback.py
+++ b/examples/substep_callback.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Example how substep_callback can be used to detect contacts/penetrations that
+are not visible in between steps.
+
+In this example a sphere pushes a cylinder, which then slides away.
+The entirety of the contact and separation happens in substeps.
+
+In between steps there is always zero contacts, so the push is not observed.
+
+We use a substep_callback to get a sum of the external forces on the cylinder.
+"""
+from mujoco_py import load_model_from_xml, MjSim
+
+MODEL_XML = """
+<mujoco>
+    <size nuserdata="1"/>
+    <worldbody>
+        <body name="robot" pos="0 0 0">
+            <geom rgba="1 0 0 1" size="0.15" type="sphere"/>
+            <joint axis="1 0 0" damping="1" name="j" type="slide"/>
+        </body>
+        <body name="cylinder" pos=".5 0 0">
+            <geom size="0.15 0.15" type="cylinder"/>
+            <joint axis="1 0 0" damping="10" type="slide"/>
+        </body>
+    </worldbody>
+    <actuator>
+        <position joint="j" kp="2000"/>
+    </actuator>
+</mujoco>
+"""
+
+fn = '''
+    #define MIN(a, b) (a < b ? a : b)
+    void fun(const mjModel* m, mjData* d) {
+        for (int i = 0; i < d->ncon; i++) {
+            pen_sum += MIN(d->contact[i].dist, 0);
+        }
+    }
+'''
+
+sim = MjSim(load_model_from_xml(MODEL_XML), nsubsteps=50,
+            substep_callback=fn, userdata_names=['pen_sum'])
+t = 0
+while t < 10:
+    t += 1
+    sim.data.ctrl[0] = .2
+    print('t', t)
+    sim.step()
+    # verify that there are no contacts visible between steps
+    assert sim.data.ncon == 0, 'No contacts should be detected here'
+    # verify that contacts (and penetrations) are visible to substep_callback
+    if t > 1:
+        assert sim.data.get_struct_dict('pen_sum') < 0  # detected penetrations

--- a/examples/substep_callback.py
+++ b/examples/substep_callback.py
@@ -32,16 +32,16 @@ MODEL_XML = """
 """
 
 fn = '''
-    #define MIN(a, b) (a < b ? a : b)
+    #define SQUARE(a) (a * a)
     void fun(const mjModel* m, mjData* d) {
-        for (int i = 0; i < d->ncon; i++) {
-            pen_sum += MIN(d->contact[i].dist, 0);
+        for (int i = d->ne; i < d->nefc; i++) {
+            pos_sum += SQUARE(d->efc_pos[i]);
         }
     }
 '''
 
 sim = MjSim(load_model_from_xml(MODEL_XML), nsubsteps=50,
-            substep_callback=fn, userdata_names=['pen_sum'])
+            substep_callback=fn, userdata_names=['pos_sum'])
 t = 0
 while t < 10:
     t += 1
@@ -52,4 +52,4 @@ while t < 10:
     assert sim.data.ncon == 0, 'No contacts should be detected here'
     # verify that contacts (and penetrations) are visible to substep_callback
     if t > 1:
-        assert sim.data.get_struct_dict('pen_sum') < 0  # detected penetrations
+        assert sim.data.get_userdata('pos_sum') > 0  # detected collision

--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -330,7 +330,11 @@ def build_fn_cleanup(name):
     '''
     if not os.environ.get('MUJOCO_PY_DEBUG_FN_BUILDER', False):
         for f in glob.glob(name + '*'):
-            os.remove(f)
+            try:
+                os.remove(f)
+            except PermissionError as e:
+                # This happens trying to remove libraries on appveyor
+                print('Error removing {}, continuing anyway: {}'.format(f, e))
 
 
 def build_callback_fn(function_string, userdata_names=[]):

--- a/mujoco_py/cymj.pyx
+++ b/mujoco_py/cymj.pyx
@@ -164,5 +164,3 @@ def load_model_from_mjb(bytes mjb_bytes):
     if model == NULL:
         raise Exception('%s\nFailed to load MJB')
     return WrapMjModel(model)
-
-

--- a/mujoco_py/generated/wrappers.pxi
+++ b/mujoco_py/generated/wrappers.pxi
@@ -2496,6 +2496,10 @@ cdef class PyMjData(object):
     def get_sensordata(self, name):
         raise RuntimeError("get_sensor should be used instead of get_sensordata")
 
+    def get_userdata(self, name):
+        id = self._model.userdata_name2id(name)
+        return self._userdata[id]
+
     def get_mocap_pos(self, name):
         body_id = self._model.body_name2id(name)
         mocap_id = self._model.body_mocapid[body_id]

--- a/mujoco_py/mjsim.pyx
+++ b/mujoco_py/mjsim.pyx
@@ -78,12 +78,6 @@ cdef class MjSim(object):
         self.udd_state = None
         self.udd_callback = udd_callback
         self.extras = {}
-        # TODO: add magic name-based indexing to userdata based on fields
-        # TODO: add convenient way to get field info from data
-        # assert isinstance(userdata_fields, list), 'fields must be list'
-        # assert model.nuserdata >= len(userdata_fields), \
-        #     'userdata {} < len {}'.format(model.nuserdata, len(userdata_fields))
-        # self.userdata_fields = userdata_fields
         self.set_substep_callback(substep_callback)
 
     def reset(self):
@@ -189,7 +183,14 @@ cdef class MjSim(object):
 
     def set_substep_callback(self, substep_callback):
         '''
-        TODO: tons of docs right here
+        Set a substep callback function.
+
+        If `substep_callback` is a string, compile to function pointer and set.
+            See `builder.build_callback_fn()` for documentation.
+
+        If `substep_callback` is an int, we interpret it as a function pointer.
+
+        If `substep_callback` is None, we disable substep_callbacks.
         '''
         if substep_callback is None:
             self.substep_callback_ptr = 0
@@ -199,7 +200,7 @@ cdef class MjSim(object):
             self.substep_callback_ptr = build_callback_fn(substep_callback,
                                                           self.model.userdata_names)
         else:
-            raise TypeError('substep_callback must be string or int or None')
+            raise TypeError('invalid: {}'.format(type(substep_callback)))
 
     def step_udd(self):
         if self._udd_callback is None:

--- a/mujoco_py/pxd/mjdata.pxd
+++ b/mujoco_py/pxd/mjdata.pxd
@@ -4,7 +4,7 @@ include "mjmodel.pxd"
 cdef extern from "mjdata.h" nogil:
 
     #---------------------------- primitive types (mjt) ------------------------------------
-        
+
     ctypedef enum mjtWarning:            # warning types
         mjWARN_INERTIA      = 0,        # (near) singular inertia matrix
         mjWARN_CONTACTFULL,             # too many contacts in contact list
@@ -282,28 +282,28 @@ cdef extern from "mjdata.h" nogil:
         mjtNum*   cfrc_ext              # com-based external force on body         (nbody x 6)
 
 
-# #---------------------------------- callback function types ----------------------------
-#
-# # generic MuJoCo function
-# typedef void (*mjfGeneric)(const mjModel* m, mjData* d)
-#
-# # sensor simulation
-# typedef void (*mjfSensor)(const mjModel* m, mjData* d, int stage)
-#
-# # timer
-# typedef long long int (*mjfTime)(void);
-#
-# # actuator dynamics, gain, bias
-# typedef mjtNum (*mjfAct)(const mjModel* m, const mjData* d, int id);
-#
-# # solver impedance
-# typedef mjtNum (*mjfSolImp)(const mjModel* m, const mjData* d, int id,
-#                             mjtNum distance, mjtNum* constimp);
-#
-# # solver reference
-# typedef void (*mjfSolRef)(const mjModel* m, const mjData* d, int id,
-#                           mjtNum constimp, mjtNum imp, int dim, mjtNum* ref);
-#
-# # collision detection
-# typedef int (*mjfCollision)(const mjModel* m, const mjData* d,
-#                             mjContact* con, int g1, int g2, mjtNum margin);
+#---------------------------------- callback function types ----------------------------
+
+# generic MuJoCo function
+ctypedef void (*mjfGeneric)(const mjModel* m, mjData* d)
+
+# sensor simulation
+ctypedef void (*mjfSensor)(const mjModel* m, mjData* d, int stage)
+
+# timer
+ctypedef long long int (*mjfTime)();
+
+# actuator dynamics, gain, bias
+ctypedef mjtNum (*mjfAct)(const mjModel* m, const mjData* d, int id);
+
+# solver impedance
+ctypedef mjtNum (*mjfSolImp)(const mjModel* m, const mjData* d, int id,
+                             mjtNum distance, mjtNum* constimp);
+
+# solver reference
+ctypedef void (*mjfSolRef)(const mjModel* m, const mjData* d, int id,
+                           mjtNum constimp, mjtNum imp, int dim, mjtNum* ref);
+
+# collision detection
+ctypedef int (*mjfCollision)(const mjModel* m, const mjData* d,
+                             mjContact* con, int g1, int g2, mjtNum margin);

--- a/mujoco_py/tests/test_substep.py
+++ b/mujoco_py/tests/test_substep.py
@@ -128,15 +128,13 @@ class TestSubstep(unittest.TestCase):
         fields = ['ctrl_max']
         model = load_model_from_xml(XML.format(nuserdata=1))
         model.set_userdata_names(fields)
-        sim = MjSim(model)
-        sim.set_substep_callback(fn)
+        sim = MjSim(model, substep_callback=fn)
         sim.step()
         self.assertEqual(sim.data.userdata[0], 0)
         sim.data.ctrl[:] = [1, 2]
         sim.step()
         self.assertEqual(sim.data.userdata[0], 2)
-        sim2 = MjSim(sim.model)
-        sim2.set_substep_callback(fn)
+        sim2 = MjSim(sim.model, substep_callback=sim.substep_callback_ptr)
         sim2.step()
         self.assertEqual(sim2.data.userdata[0], 0)
         sim2.data.ctrl[:] = [.1, .2]
@@ -152,8 +150,7 @@ class TestSubstep(unittest.TestCase):
             }
         '''
         model = load_model_from_xml(XML.format(nuserdata=9))
-        sim = MjSim(model)
-        sim.set_substep_callback(fn)
+        sim = MjSim(model, substep_callback=fn)
         sim.data.ctrl[:] = [9, 13]
         for _ in range(30):
             sim.step()

--- a/mujoco_py/tests/test_substep.py
+++ b/mujoco_py/tests/test_substep.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+import unittest
+from mujoco_py import load_model_from_xml, MjSim
+
+'''
+TODO (REMOVEME):
+  - Test calling mujoco functions from within callback (e.g. quaternion math)
+'''
+
+
+XML = '''
+<mujoco>
+    <size nuserdata="{nuserdata}"/>
+    <worldbody>
+        <body pos="0 0 0">
+            <joint name="j1" type="hinge" axis="1 0 0"/>
+            <geom type="sphere" size=".5"/>
+            <body pos="0 0 1">
+                <joint name="j2" type="hinge" axis="1 0 0"/>
+                <geom type="sphere" size=".5"/>
+            </body>
+        </body>
+    </worldbody>
+    <actuator>
+        <position joint="j1" kp="100"/>
+        <position joint="j2" kp="100"/>
+    </actuator>
+</mujoco>
+'''
+
+HELLO_FN = '''
+    #include <stdio.h>
+    void fun(const mjModel* m, mjData* d) {
+        printf("hello");
+    }
+'''
+
+INCREMENT_FN = '''
+    void fun(const mjModel* m, mjData* d) {
+        d->userdata[0] += 1;
+    }
+'''
+
+
+class TestSubstep(unittest.TestCase):
+    def test_hello(self):
+        sim = MjSim(load_model_from_xml(XML.format(nuserdata=0)))
+        sim.set_substep_callback(HELLO_FN)
+        sim.step()  # should print 'hello'
+
+    def test_increment(self):
+        sim = MjSim(load_model_from_xml(XML.format(nuserdata=1)))
+        sim.set_substep_callback(INCREMENT_FN)
+        self.assertEqual(sim.data.userdata[0], 0)
+        sim.step()  # should increment userdata[0]
+        self.assertEqual(sim.data.userdata[0], 1)
+        # Test again with different nsubsteps, reuse model
+        sim = MjSim(sim.model, nsubsteps=7)
+        sim.set_substep_callback(INCREMENT_FN)
+        self.assertEqual(sim.data.userdata[0], 0)
+        sim.step()  # should increment userdata[0] 7 times
+        self.assertEqual(sim.data.userdata[0], 7)
+
+    def test_sum_ctrl(self):
+        fn = '''
+            void fun(const mjModel* m, mjData* d) {
+                for (int i = 0; i < m->nu; i++) {
+                    my_sum += d->ctrl[i];
+                }
+            }
+        '''
+        model = load_model_from_xml(XML.format(nuserdata=1))
+        model.set_userdata_names(['my_sum'])
+        sim = MjSim(model)
+        sim.set_substep_callback(fn)
+        self.assertEqual(sim.data.userdata[0], 0)
+        sim.step()  # should set userdata[0] to sum of controls
+        self.assertEqual(sim.data.userdata[0], 0)
+        sim.data.ctrl[0] = 12.
+        sim.data.ctrl[1] = .34
+        sim.step()
+        self.assertEqual(sim.data.userdata[0], 12.34)
+        sim.step()
+        self.assertEqual(sim.data.userdata[0], 24.68)
+
+    def test_penetrations(self):
+        # Test that we capture the max penetration of a falling sphere
+        # Given a single step with many substeps
+        xml = '''
+            <mujoco>
+                <size nuserdata="1"/>
+                <worldbody>
+                    <body pos="0 0 1">
+                        <joint type="free"/>
+                        <geom size=".1"/>
+                    </body>
+                    <geom type="plane" size="1 1 1"/>
+                </worldbody>
+            </mujoco>
+        '''
+        # NOTE: penetration is negative distance in contacts
+        fn = '''
+            #define MIN(a, b) (a < b ? a : b)
+            void fun(const mjModel* m, mjData* d) {
+                for (int i = 0; i < d->ncon; i++) {
+                    min_contact_dist = MIN(min_contact_dist, d->contact[i].dist);
+                }
+            }
+        '''
+        fields = ['min_contact_dist']
+        model = load_model_from_xml(xml)
+        model.set_userdata_names(fields)
+        sim = MjSim(model, nsubsteps=1000)
+        sim.set_substep_callback(fn)
+        self.assertEqual(sim.data.userdata[0], 0)
+        sim.step()
+        self.assertEqual(sim.data.ncon, 1)  # Assert we have a contact
+        self.assertLess(sim.data.contact[0].dist, 0)  # assert penetration
+        # Assert that min penetration is much less than current penetration
+        self.assertLess(sim.data.userdata[0], 10 * sim.data.contact[0].dist)
+
+    def test_reuse(self):
+        ''' Test that we can re-use a substep_callback between sims '''
+        fn = '''
+            #define MAX(a, b) (a > b ? a : b)
+            void fun(const mjModel* m, mjData* d) {
+                for (int i = 0; i < m->nu; i++) {
+                    ctrl_max = MAX(ctrl_max, d->ctrl[i]);
+                }
+            }
+        '''
+        fields = ['ctrl_max']
+        model = load_model_from_xml(XML.format(nuserdata=1))
+        model.set_userdata_names(fields)
+        sim = MjSim(model)
+        sim.set_substep_callback(fn)
+        sim.step()
+        self.assertEqual(sim.data.userdata[0], 0)
+        sim.data.ctrl[:] = [1, 2]
+        sim.step()
+        self.assertEqual(sim.data.userdata[0], 2)
+        sim2 = MjSim(sim.model)
+        sim2.set_substep_callback(fn)
+        sim2.step()
+        self.assertEqual(sim2.data.userdata[0], 0)
+        sim2.data.ctrl[:] = [.1, .2]
+        sim2.step()
+        self.assertEqual(sim2.data.userdata[0], .2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ glfw>=1.4.0
 numpy>=1.11
 Cython>=0.25.2
 imageio>=2.1.2
-cffi>=1.11.2
+cffi>=1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ glfw>=1.4.0
 numpy>=1.11
 Cython>=0.25.2
 imageio>=2.1.2
+cffi>=1.11.2

--- a/scripts/gen_wrappers.py
+++ b/scripts/gen_wrappers.py
@@ -742,6 +742,7 @@ def main():
             extra += _add_named_access_methods('light', 'light_xpos', 'xpos')
             extra += _add_named_access_methods('light', 'light_xdir', 'xdir')
             extra += _add_named_access_methods('sensor', 'sensordata', None)
+            extra += _add_named_access_methods('userdata', 'userdata', None)
 
             for pose_type in ('pos', 'quat'):
                 extra += """


### PR DESCRIPTION
Take two with this PR, breaking out the other two functionalities that changed.

Once un-based on the gen_wrappers model userdata changes, this adds the ability to compile callback functions.  The first use of these is a per-substep callback.

Much of the documentation is TODO, but I think we're out of the woods with the naming cleanup that was requested.