### PR TITLE
bump cython to 0.27.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 glfw>=1.4.0
 numpy>=1.11
-Cython>=0.25.2
+Cython>=0.27.2
 imageio>=2.1.2
 cffi>=1.10


### PR DESCRIPTION
It looks like the recent patches fixed the issue we had with newer cython.

Fixes #131 