### PR TITLE
Discover mujoco using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,36 @@ Add the path to the mujoco bin directory to your dynamic loader:
 
 This is particularly useful on Ubuntu 14.04, which does not have a GLFW package.
 
+### Locating the MuJoCo Pro binaries and MuJoCo Pro license key
+
+`mujoco-py` assumes your MuJoCo binaries and MuJoCo license key are located at
+`~/.mujoco/mjpro150` and `/.mujoco/mjkey.txt` respectively.
+
+If this is not the case for you installation, you may override this default by
+specifying environment variables. This is particularly useful in cloud, cluster,
+and Docker environments.
+
+    export MUJOCO_PY_MUJOCO_PATH=/path/to/your/.mujoco/or/equivalent
+
+`MUJOCO_PY_MUJOCO_PATH` specifies an alternative path to the directory that is
+usually `~/.mujoco`. If this environment variable is set and non-empty, it is
+used as the directory prefix for `mjpro150` and `mjkey.txt`,
+replacing `~/.mujoco`.
+
+    export MUJOCO_LICENSE_PATH=/path/to/your/mujoco/pro/license
+
+`MUJOCO_LICENSE_PATH` provides an alternative path to the MuJoCo Pro key. If set
+and non-empty, this environment variable overrides the path to the file
+containing the MuJoCo Pro license key, including any alternative path induced by
+`MUJOCO_PY_MUJOCO_PATH`.
+
+    export MUJOCO_PY_MJPRO_PATH=/path/to/your/mjpro150
+
+`MUJOCO_PY_MJPRO_PATH` provides and alternative path to the `mjpro150`
+directory. If set and non-empty, this environment variable overrides the path
+to the `mjpro150` directory, including any alternative path induced by
+`MUJOCO_PY_MUJOCO_PATH`.
+
 ## Usage Examples
 
 A number of examples demonstrating some advanced features of `mujoco-py` can be found in [`examples/`](/./examples/). These include:

--- a/mujoco_py/tests/test_utils.py
+++ b/mujoco_py/tests/test_utils.py
@@ -1,0 +1,31 @@
+import os
+from os.path import join, expanduser, abspath
+
+from mujoco_py import utils
+
+def test_discover_mujoco():
+    ''' Testing MuJoCo discovery '''
+
+    # Defaults
+    mjpro_path, key_path = utils.discover_mujoco()
+    assert mjpro_path == join(expanduser('~'), '.mujoco', 'mjpro150')
+    assert key_path == join(expanduser('~'), '.mujoco', 'mjkey.txt')
+
+    # Override MUJOCO_PY_MUJOCO_PATH
+    override_path = join('my','mujoco','path')
+    os.environ[utils._MUJOCO_PY_MUJOCO_PATH] = override_path
+    mjpro_path, key_path = utils.discover_mujoco()
+    assert mjpro_path == abspath(join(override_path, 'mjpro150'))
+    assert key_path == abspath(join(override_path, 'mjkey.txt'))
+
+    # Override MUJOCO_LICENSE_KEY
+    override_key = join('path', 'to', 'my', 'key.txt')
+    os.environ[utils._MUJOCO_LICENSE_KEY] = override_key
+    _, key_path = utils.discover_mujoco()
+    assert key_path == abspath(override_key)
+
+    # Override MUJOCO_PY_MJPRO_PATH
+    override_mjpro = join('path', 'to', 'my', 'mjpro')
+    os.environ[utils._MUJOCO_PY_MJPRO_PATH] = override_mjpro
+    mjpro_path, _ = utils.discover_mujoco()
+    assert mjpro_path == abspath(override_mjpro)

--- a/mujoco_py/utils.py
+++ b/mujoco_py/utils.py
@@ -1,9 +1,12 @@
 import copy
-from os.path import join, expanduser
+import os
+from os.path import join, expanduser, abspath
 
 import numpy as np
 
-
+_MUJOCO_PY_MUJOCO_PATH = 'MUJOCO_PY_MUJOCO_PATH'
+_MUJOCO_LICENSE_KEY = 'MUJOCO_LICENSE_KEY'
+_MUJOCO_PY_MJPRO_PATH = 'MUJOCO_PY_MJPRO_PATH'
 
 def remove_empty_lines(string):
     lines = []
@@ -46,12 +49,30 @@ def rec_copy(node):
 def discover_mujoco():
     """
     Discovers where MuJoCo is located in the file system.
-    Currently assumes path is in ~/.mujoco
+    Assumes it is in ~/.mujoco, unless one of the environment variables
+    MUJOCO_PY_MUJOCO_PATH, MUJOCO_PY_MJPRO_PATH, and MUJOCO_LICENSE_KEY are set.
 
     Returns:
     - mjpro_path (str): Path to MuJoCo Pro 1.50 directory.
     - key_path (str): Path to the MuJoCo license key.
     """
+    # Defaults to ~/.mujoco
     key_path = join(expanduser('~'), '.mujoco', 'mjkey.txt')
     mjpro_path = join(expanduser('~'), '.mujoco', 'mjpro150')
+
+    # Check for an alternative .mujoco directory
+    if os.getenv(_MUJOCO_PY_MUJOCO_PATH):
+        key_path = join(
+            abspath(os.getenv(_MUJOCO_PY_MUJOCO_PATH)),
+            'mjkey.txt')
+        mjpro_path = join(
+            abspath(os.getenv(_MUJOCO_PY_MUJOCO_PATH)), 'mjpro150')
+
+    # Check for alternative explicit paths to mjpro150 and mjkey.txt
+    if os.getenv(_MUJOCO_LICENSE_KEY):
+        key_path = abspath(os.getenv(_MUJOCO_LICENSE_KEY))
+
+    if os.getenv(_MUJOCO_PY_MJPRO_PATH):
+        mjpro_path = abspath(os.getenv(_MUJOCO_PY_MJPRO_PATH))
+
     return (mjpro_path, key_path)


### PR DESCRIPTION
Adds the option to locate mjpro150 and mjkey.txt using environment
variables.

This is extremely useful when using mujoco_py in a cluster environment
or with Docker.

* MUJOCO_PY_MUJOCO_PATH
Provides an alternative path to the directory that is usually
~/.mujoco.
If this environment variable is set and non-empty, it is used as the
directory prefix for mjpro150 and mjkey.txt, replacing ~/.mujoco.

* MUJOCO_LICENSE_PATH
Provides an alternative path to the MuJoCo Pro key.
If set and non-empty, this environment variable overrides the path to
the file containing the MuJoCo Pro license key, including any
alternative path induced by MUJOCO_PY_MUJOCO_PATH.

* MUJOCO_PY_MJPRO_PATH
Provides and alternative path to the mjpro150 binaries.
If set and non-empty, this environment variable overrides the path to
the mjpro150 binaries, including any alternative path induced by
MUJOCO_PY_MUJOCO_PATH.