### PR TITLE
Added mj_ray function

### DIFF
--- a/mujoco_py/generated/wrappers.pxi
+++ b/mujoco_py/generated/wrappers.pxi
@@ -4126,6 +4126,9 @@ def _mj_setTotalmass(PyMjModel m, float newmass):
 def _mj_version():
     return mj_version()
 
+def _mj_ray(PyMjModel m, PyMjData d, np.ndarray[np.float64_t, mode="c", ndim=1] pnt, np.ndarray[np.float64_t, mode="c", ndim=1] vec, np.ndarray[np.uint8_t, mode="c", ndim=1] geomgroup, np.uint8_t flg_static, int bodyexclude, np.ndarray[int, mode="c", ndim=1] geomid):
+    return mj_ray(m.ptr, d.ptr, &pnt[0], &vec[0], &geomgroup[0], flg_static, bodyexclude, &geomid[0])
+
 def _mj_rayHfield(PyMjModel m, PyMjData d, int geomid, np.ndarray[np.float64_t, mode="c", ndim=1] pnt, np.ndarray[np.float64_t, mode="c", ndim=1] vec):
     return mj_rayHfield(m.ptr, d.ptr, geomid, &pnt[0], &vec[0])
 

--- a/scripts/gen_wrappers.py
+++ b/scripts/gen_wrappers.py
@@ -371,6 +371,16 @@ def get_funcs(fname):
                         "np.ndarray[np.float64_t, mode=\"c\", ndim=1] " + var_name)
                     c_args_string.append("&%s[0]" % var_name)
                     continue
+                if data_type == "mjtByte":
+                    py_args_string.append("np.uint8_t " + var_name)
+                    c_args_string.append(var_name)
+                    continue
+                if data_type == "mjtByte*":
+                    py_args_string.append(
+                        "np.ndarray[np.uint8_t, mode=\"c\", ndim=1] " + var_name
+                    )
+                    c_args_string.append("&%s[0]" % var_name)
+                    continue
                 if data_type[:2] == "mj" and data_type[-1] == "*":
                     py_args_string.append(
                         "PyMj" + data_type[2:-1] + " " + var_name)
@@ -384,6 +394,15 @@ def get_funcs(fname):
                 if data_type in "int":
                     py_args_string.append("int " + var_name)
                     c_args_string.append(var_name)
+                    continue
+                if data_type in "int*":
+                    if func_name not in ["mj_ray"]:
+                        skip = True
+                        break
+                    else:
+                        py_args_string.append(
+                            "np.ndarray[int, mode=\"c\", ndim=1] " + var_name)
+                        c_args_string.append("&%s[0]" % var_name)
                     continue
                 # XXX
                 skip = True

--- a/scripts/gen_wrappers.py
+++ b/scripts/gen_wrappers.py
@@ -396,6 +396,7 @@ def get_funcs(fname):
                     c_args_string.append(var_name)
                     continue
                 if data_type in "int*":
+                    # Skip function with unknown element size
                     if func_name not in ["mj_ray"]:
                         skip = True
                         break

--- a/scripts/gen_wrappers.py
+++ b/scripts/gen_wrappers.py
@@ -399,10 +399,9 @@ def get_funcs(fname):
                     if func_name not in ["mj_ray"]:
                         skip = True
                         break
-                    else:
-                        py_args_string.append(
-                            "np.ndarray[int, mode=\"c\", ndim=1] " + var_name)
-                        c_args_string.append("&%s[0]" % var_name)
+                    py_args_string.append(
+                        "np.ndarray[int, mode=\"c\", ndim=1] " + var_name)
+                    c_args_string.append("&%s[0]" % var_name)
                     continue
                 # XXX
                 skip = True


### PR DESCRIPTION
We would like to add a function `mj_ray` (http://www.mujoco.org/book/reference.html#mj_ray).

To not skip the function, I added the data type conversions
* `int*` => `np.ndarray[int, mode="c", ndim=1]` only for `mj_ray`
* `mjtByte` => `np.uint8_t`
* `mjtByte*` => `np.ndarray[uint8_t, mode="c", ndim=1]`
