### PR TITLE
Fix activation

### DIFF
--- a/mujoco_py/__init__.py
+++ b/mujoco_py/__init__.py
@@ -1,4 +1,4 @@
-from mujoco_py.builder import cymj, ignore_mujoco_warnings, functions, MujocoException
+from mujoco_py.builder import cymj, ignore_mujoco_warnings, functions, MujocoException, activate
 from mujoco_py.generated import const
 from mujoco_py.mjrenderpool import MjRenderPool
 from mujoco_py.mjviewer import MjViewer, MjViewerBasic
@@ -25,3 +25,5 @@ __all__ = ['MjSim', 'MjSimState', 'MjSimPool',
            'load_model_from_mjb',
            'ignore_mujoco_warnings', 'const', "functions",
            "__version__", "get_version"]
+
+builder.activate()

--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -512,7 +512,8 @@ for func_name in dir(cymj):
     if func_name.startswith("_mj"):
         setattr(functions, func_name[1:], getattr(cymj, func_name))
 
-functions.mj_activate(key_path)
+def activate():
+    functions.mj_activate(key_path)
 
 # Set user-defined callbacks that raise assertion with message
 cymj.set_warning_callback(user_warning_raise_exception)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ class Build(DistutilsBuild):
             "mujoco_py.builder", builder_path)
         builder = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(builder)
-        builder.activate()
         DistutilsBuild.run(self)
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class Build(DistutilsBuild):
             "mujoco_py.builder", builder_path)
         builder = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(builder)
-
+        builder.activate()
         DistutilsBuild.run(self)
 
 


### PR DESCRIPTION
Should fix https://github.com/openai/mujoco-py/issues/66 https://github.com/openai/mujoco-py/issues/99 https://github.com/openai/mujoco-py/issues/103
As mentioned in https://github.com/openai/mujoco-py/issues/103 , for some reason `exec_module` calls for `builder.py` twice, and `mj_activate` fails on the second one. Not sure if it is valid workaround though.