### PR TITLE
Limit 

### DIFF
--- a/mujoco_py/opengl_context.pyx
+++ b/mujoco_py/opengl_context.pyx
@@ -111,7 +111,7 @@ class GlfwContext(OpenGLContext):
             # HAX: When running on a Mac with retina screen, the size
             # sometimes doubles
             width, height = glfw.get_framebuffer_size(self.window)
-            if target_width != width:
+            if sys.platform == 'darwin' and target_width != width:
                 glfw.set_window_size(self.window, target_width // 2, target_height // 2)
 
     @staticmethod

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (1, 50, 1, 56)
+version_info = (1, 50, 1, 57)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 


### PR DESCRIPTION
The Mac OS X workaround is overly sensitive and is being triggered on my Linux system, with unhappy results (only a quarter of the display is rendered). Added a platform check to reduce false positive rate.