### PR TITLE
set arbitrary resolution for rendering

### DIFF
--- a/mujoco_py/mjviewer.py
+++ b/mujoco_py/mjviewer.py
@@ -205,10 +205,11 @@ class MjViewer(MjViewerBasic):
         self._markers[:] = []
         self._overlay.clear()
 
-    def _read_pixels_as_in_window(self):
-        # Reads pixels with markers and overlay from the same camera as screen.
-        resolution = glfw.get_framebuffer_size(
-            self.sim._render_context_window.window)
+    def _read_pixels_as_in_window(self, resolution=None):
+        if resolution is None:
+            # Reads pixels with markers and overlay from the same camera as screen.
+            resolution = glfw.get_framebuffer_size(
+                self.sim._render_context_window.window)
 
         resolution = np.array(resolution)
         resolution = resolution * min(1000 / np.min(resolution), 1)

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (1, 50, 1, 56)
+version_info = (1, 50, 1, 57)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 


### PR DESCRIPTION
I tried to call `MjViewer._read_pixels_as_in_window` directly from my code, and got error saying "Buffer size too big" because my monitor is bigger than maximum buffer size defined [here](https://github.com/openai/mujoco-py/blob/master/mujoco_py/gl/osmesashim.c#L7-L10).

This PR enables to pass arbitrary resolution as an argument to that function.

This is perhaps useful for fixing [this issue](https://github.com/openai/gym/issues/1041).