### PR TITLE
Delete temporary file after loading model from XML.

### DIFF
--- a/mujoco_py/cymj.pyx
+++ b/mujoco_py/cymj.pyx
@@ -139,12 +139,12 @@ def load_model_from_xml(str xml_str):
     cdef char errstr[300]
     cdef mjModel *model
     with wrap_mujoco_warning():
-        with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as fp:
+        with tempfile.NamedTemporaryFile(suffix=".xml") as fp:
             fp.write(xml_str.encode())
             fp.flush()
-        model = mj_loadXML(fp.name.encode(), NULL, errstr, 300)
+            model = mj_loadXML(fp.name.encode(), NULL, errstr, 300)
     if model == NULL:
-        raise Exception('%s\nFailed to load XML from file: %s. mj_loadXML error: %s' % (xml_str, fp.name, errstr,))
+        raise Exception('%s\nFailed to load XML from string. mj_loadXML error: %s' % (xml_str, errstr,))
     return WrapMjModel(model)
 
 

--- a/mujoco_py/cymj.pyx
+++ b/mujoco_py/cymj.pyx
@@ -146,7 +146,7 @@ def load_model_from_xml(str xml_str):
             fp.write(xml_str.encode())
             fp.flush()
         model = mj_loadXML(fp.name.encode(), NULL, errstr, 300)
-    os.path.remove(fp.name)
+    os.remove(fp.name)
     if model == NULL:
         raise Exception('%s\nFailed to load XML from string. mj_loadXML error: %s' % (xml_str, errstr,))
     return WrapMjModel(model)


### PR DESCRIPTION
If many models are loaded from a string of XML, these files can clutter up the `/tmp` directory.