### PR TITLE
Terminate viewer before exit, fixed NameError "exit"

### DIFF
--- a/mujoco_py/mjviewer.py
+++ b/mujoco_py/mjviewer.py
@@ -8,6 +8,7 @@ from multiprocessing import Process, Queue
 from mujoco_py.utils import rec_copy, rec_assign
 import numpy as np
 import imageio
+from sys import exit
 
 
 class MjViewerBasic(cymj.MjRenderContextWindow):
@@ -49,6 +50,7 @@ class MjViewerBasic(cymj.MjRenderContextWindow):
         if self.window is None:
             return
         elif glfw.window_should_close(self.window):
+            glfw.terminate()
             exit(0)
 
         with self._gui_lock:
@@ -60,6 +62,7 @@ class MjViewerBasic(cymj.MjRenderContextWindow):
         if action == glfw.RELEASE and key == glfw.KEY_ESCAPE:
             print("Pressed ESC")
             print("Quitting.")
+            glfw.terminate()
             exit(0)
 
     def _cursor_pos_callback(self, window, xpos, ypos):


### PR DESCRIPTION
Added glfw.terminate() before calling exit() when closing the viewer.
Added "from sys import exit" to fixed NameError on exit()