### PR TITLE
build at install time

### DIFF
--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -238,7 +238,8 @@ class MujocoExtensionBuilder():
 
     def get_so_file_path(self):
         dir_path = abspath(dirname(__file__))
-        return join(dir_path, "generated", "cymj_%s.so" % self.version)
+        python_version = str(sys.version_info.major) + str(sys.version_info.minor)
+        return join(dir_path, "generated", "cymj_{}_{}.so".format(self.version, python_version))
 
 
 class WindowsExtensionBuilder(MujocoExtensionBuilder):

--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -98,6 +98,7 @@ The easy solution is to `import mujoco_py` _before_ `import glfw`.
             mod = load_dynamic_ext('cymj', cext_so_path)
     return mod
 
+
 def _ensure_set_env_var(var_name, lib_path):
     paths = os.environ.get(var_name, "").split(":")
     paths = [os.path.abspath(path) for path in paths]
@@ -107,6 +108,7 @@ def _ensure_set_env_var(var_name, lib_path):
                         "Please add following line to .bashrc:\n"
                         "export %s=$%s:%s" % (var_name, os.environ.get(var_name, ""),
                                               var_name, var_name, lib_path))
+
 
 def load_dynamic_ext(name, path):
     ''' Load compiled shared object and return as python module. '''
@@ -236,8 +238,6 @@ class MujocoExtensionBuilder():
 
     def get_so_file_path(self):
         dir_path = abspath(dirname(__file__))
-
-        python_version = str(sys.version_info.major) + str(sys.version_info.minor)
         return join(dir_path, "generated", "cymj_%s.so" % self.version)
 
 
@@ -258,7 +258,6 @@ class LinuxCPUExtensionBuilder(MujocoExtensionBuilder):
             join(self.CYMJ_DIR_PATH, "gl", "osmesashim.c"))
         self.extension.libraries.extend(['glewosmesa', 'OSMesa', 'GL'])
         self.extension.runtime_library_dirs = [join(mjpro_path, 'bin')]
-
 
     def _build_impl(self):
         so_file_path = super()._build_impl()
@@ -469,8 +468,10 @@ def build_callback_fn(function_string, userdata_names=[]):
     build_fn_cleanup(name)
     return module.lib.__fun
 
+
 def activate():
     functions.mj_activate(key_path)
+
 
 mjpro_path, key_path = discover_mujoco()
 cymj = load_cython_ext(mjpro_path)

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (1, 50, 1, 59)
+version_info = (1, 50, 1, 60)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-import importlib
-from distutils.command.build import build as DistutilsBuild
-from os.path import abspath, join, dirname, realpath
+from os.path import join, dirname, realpath
 from setuptools import find_packages, setup
 
 with open(join("mujoco_py", "version.py")) as version_file:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 from os.path import join, dirname, realpath
 from setuptools import find_packages, setup
+from distutils.command.build import build as DistutilsBuild
+
 
 with open(join("mujoco_py", "version.py")) as version_file:
     exec(version_file.read())
@@ -17,6 +19,13 @@ packages = find_packages()
 for p in packages:
     assert p == 'mujoco_py' or p.startswith('mujoco_py.')
 
+
+class Build(DistutilsBuild):
+    def run(self):
+        import mujoco_py  # noqa: force build
+        DistutilsBuild.run(self)
+
+
 setup(
     name='mujoco-py',
     version=__version__,  # noqa
@@ -27,6 +36,7 @@ setup(
     include_package_data=True,
     package_dir={'mujoco_py': 'mujoco_py'},
     package_data={'mujoco_py': ['generated/*.so']},
+    cmdclass={'build': Build},
     install_requires=read_requirements_file('requirements.txt'),
     tests_require=read_requirements_file('requirements.dev.txt'),
 )


### PR DESCRIPTION
this forces a build to happen at install time.

Users can still use environment variables to force a specific kind of build at runtime.