### PR TITLE
Simplifying some of the install criterion

### DIFF
--- a/mujoco_py/__init__.py
+++ b/mujoco_py/__init__.py
@@ -1,4 +1,16 @@
-from mujoco_py.builder import cymj, ignore_mujoco_warnings, functions, MujocoException
+#!/usr/bin/env python
+import os
+from ctypes import cdll
+
+
+MJ_BIN_PATH = '.mujoco/mjpro150/bin'.split('/')
+cdll.LoadLibrary(os.path.join(os.getenv('HOME'), *MJ_BIN_PATH, 'libmujoco150.dylib'))
+cdll.LoadLibrary(os.path.join(os.getenv('HOME'), *MJ_BIN_PATH, 'libglfw.3.dylib'))
+
+
+import mujoco_py.cymj as cymj
+
+from mujoco_py.builder import ignore_mujoco_warnings, functions, MujocoException
 from mujoco_py.generated import const
 from mujoco_py.mjrenderpool import MjRenderPool
 from mujoco_py.mjviewer import MjViewer, MjViewerBasic

--- a/mujoco_py/__init__.py
+++ b/mujoco_py/__init__.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
-import os
-from ctypes import cdll
+# import os
+# from ctypes import cdll
+#
+#
+# MJ_BIN_PATH = '.mujoco/mjpro150/bin'.split('/')
+# cdll.LoadLibrary(os.path.join(os.getenv('HOME'), *MJ_BIN_PATH, 'libmujoco150.dylib'))
+# cdll.LoadLibrary(os.path.join(os.getenv('HOME'), *MJ_BIN_PATH, 'libglfw.3.dylib'))
+#
+#
+# import mujoco_py.cymj as cymj
 
-
-MJ_BIN_PATH = '.mujoco/mjpro150/bin'.split('/')
-cdll.LoadLibrary(os.path.join(os.getenv('HOME'), *MJ_BIN_PATH, 'libmujoco150.dylib'))
-cdll.LoadLibrary(os.path.join(os.getenv('HOME'), *MJ_BIN_PATH, 'libglfw.3.dylib'))
-
-
-import mujoco_py.cymj as cymj
-
-from mujoco_py.builder import ignore_mujoco_warnings, functions, MujocoException
+from mujoco_py.builder import cymj, ignore_mujoco_warnings, functions, MujocoException
 from mujoco_py.generated import const
 from mujoco_py.mjrenderpool import MjRenderPool
 from mujoco_py.mjviewer import MjViewer, MjViewerBasic

--- a/mujoco_py/__init__.py
+++ b/mujoco_py/__init__.py
@@ -30,5 +30,9 @@ __all__ = ['MjSim', 'MjSimState',
            "__version__", "get_version"]
 
 
+# Print out a warning if we can't find the key.
+# this is nicer than failing activation, which we can not do in python.
+# The mujoco library exits the process forcibly, in a way we can't try/catch.
+mujoco_py.builder.find_key()
 if not os.environ.get('MUJOCO_PY_SKIP_ACTIVATE'):
     mujoco_py.builder.activate()

--- a/mujoco_py/__init__.py
+++ b/mujoco_py/__init__.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-# import os
-# from ctypes import cdll
-#
-#
-# MJ_BIN_PATH = '.mujoco/mjpro150/bin'.split('/')
-# cdll.LoadLibrary(os.path.join(os.getenv('HOME'), *MJ_BIN_PATH, 'libmujoco150.dylib'))
-# cdll.LoadLibrary(os.path.join(os.getenv('HOME'), *MJ_BIN_PATH, 'libglfw.3.dylib'))
-#
-#
-# import mujoco_py.cymj as cymj
-
 from mujoco_py.builder import cymj, ignore_mujoco_warnings, functions, MujocoException
 from mujoco_py.generated import const
 from mujoco_py.mjrenderpool import MjRenderPool

--- a/mujoco_py/__init__.py
+++ b/mujoco_py/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+import os
 from mujoco_py.builder import cymj, ignore_mujoco_warnings, functions, MujocoException
 from mujoco_py.generated import const
 from mujoco_py.mjrenderpool import MjRenderPool
@@ -27,4 +29,6 @@ __all__ = ['MjSim', 'MjSimState',
            'ignore_mujoco_warnings', 'const', "functions",
            "__version__", "get_version"]
 
-mujoco_py.builder.activate()
+
+if not os.environ.get('MUJOCO_PY_SKIP_ACTIVATE'):
+    mujoco_py.builder.activate()

--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -483,6 +483,25 @@ def build_callback_fn(function_string, userdata_names=[]):
     return module.lib.__fun
 
 
+MISSING_KEY_MESSAGE = '''
+You appear to be missing a License Key for mujoco.  We expected to find the
+file here: {}
+
+You can get licenses at this page:
+
+    https://www.roboti.us/license.html
+
+If python tries to activate an invalid license, the process will exit.
+'''
+
+
+def find_key():
+    ''' Try to find the key file, if missing, print out a big message '''
+    if exists(key_path):
+        return
+    print(MISSING_KEY_MESSAGE.format(key_path), file=sys.stderr)
+
+
 def activate():
     functions.mj_activate(key_path)
 

--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -88,6 +88,14 @@ The easy solution is to `import mujoco_py` _before_ `import glfw`.
 
     with LockFile(lockpath):
         mod = None
+        force_rebuild = os.environ.get('MUJOCO_PY_FORCE_REBUILD')
+        if force_rebuild:
+            # Try to remove the old file, ignore errors if it doesn't exist
+            print("Removing old mujoco_py cext", cext_so_path)
+            try:
+                os.remove(cext_so_path)
+            except OSError:
+                pass
         if exists(cext_so_path):
             try:
                 mod = load_dynamic_ext('cymj', cext_so_path)

--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -480,7 +480,7 @@ def activate():
 
 
 mjpro_path, key_path = discover_mujoco()
-# cymj = load_cython_ext(mjpro_path)
+cymj = load_cython_ext(mjpro_path)
 
 
 # Trick to expose all mj* functions from mujoco in mujoco_py.*
@@ -488,10 +488,10 @@ class dict2(object):
     pass
 
 
-# functions = dict2()
-# for func_name in dir(cymj):
-#     if func_name.startswith("_mj"):
-#         setattr(functions, func_name[1:], getattr(cymj, func_name))
+functions = dict2()
+for func_name in dir(cymj):
+    if func_name.startswith("_mj"):
+        setattr(functions, func_name[1:], getattr(cymj, func_name))
 
 # Set user-defined callbacks that raise assertion with message
-# cymj.set_warning_callback(user_warning_raise_exception)
+cymj.set_warning_callback(user_warning_raise_exception)

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (1, 50, 1, 59)
+version_info = (1, 50, 1, 61)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,6 @@
 #!/usr/bin/env python3
 from os.path import join, dirname, realpath
-from os import getenv
 from setuptools import find_packages, setup
-from setuptools.extension import Extension
-from Cython.Build import cythonize
-from ctypes import cdll
-import numpy as np
-
-MJ_PATH = join(getenv('HOME'), '.mujoco', 'mjpro150')
-
-# XXX this is mac specific for now
-cdll.LoadLibrary(join(MJ_PATH, 'bin', 'libmujoco150.dylib'))
-cdll.LoadLibrary(join(MJ_PATH, 'bin', 'libglfw.3.dylib'))
 
 
 with open(join("mujoco_py", "version.py")) as version_file:
@@ -30,22 +19,6 @@ for p in packages:
     assert p == 'mujoco_py' or p.startswith('mujoco_py.')
 
 
-cymjpyx = join('mujoco_py', 'cymj.pyx')
-include = join(MJ_PATH, 'include')
-mjbin = join(MJ_PATH, 'bin')
-print('include', include)
-
-
-cymj_extension = Extension(name='mujoco_py.cymj',
-                           sources=['mujoco_py/cymj.pyx'],
-                           include_dirs=[include, np.get_include()],
-                           library_dirs=[mjbin],
-                           libraries=['mujoco150', 'glfw.3'])
-
-
-ext_modules = [cymj_extension]
-
-
 setup(
     name='mujoco-py',
     version=__version__,  # noqa
@@ -56,7 +29,6 @@ setup(
     include_package_data=True,
     package_dir={'mujoco_py': 'mujoco_py'},
     package_data={'mujoco_py': ['generated/*.so']},
-    ext_modules=cythonize(ext_modules),
     install_requires=read_requirements_file('requirements.txt'),
     tests_require=read_requirements_file('requirements.dev.txt'),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python3
-import importlib
-from distutils.command.build import build as DistutilsBuild
-from os.path import abspath, join, dirname, realpath
+from os.path import join, dirname, realpath
+from os import getenv
 from setuptools import find_packages, setup
+from setuptools.extension import Extension
+from Cython.Build import cythonize
+from ctypes import cdll
+import numpy as np
+
+MJ_PATH = join(getenv('HOME'), '.mujoco', 'mjpro150')
+
+# XXX this is mac specific for now
+cdll.LoadLibrary(join(MJ_PATH, 'bin', 'libmujoco150.dylib'))
+cdll.LoadLibrary(join(MJ_PATH, 'bin', 'libglfw.3.dylib'))
+
 
 with open(join("mujoco_py", "version.py")) as version_file:
     exec(version_file.read())
@@ -19,6 +29,23 @@ packages = find_packages()
 for p in packages:
     assert p == 'mujoco_py' or p.startswith('mujoco_py.')
 
+
+cymjpyx = join('mujoco_py', 'cymj.pyx')
+include = join(MJ_PATH, 'include')
+mjbin = join(MJ_PATH, 'bin')
+print('include', include)
+
+
+cymj_extension = Extension(name='mujoco_py.cymj',
+                           sources=['mujoco_py/cymj.pyx'],
+                           include_dirs=[include, np.get_include()],
+                           library_dirs=[mjbin],
+                           libraries=['mujoco150', 'glfw.3'])
+
+
+ext_modules = [cymj_extension]
+
+
 setup(
     name='mujoco-py',
     version=__version__,  # noqa
@@ -29,6 +56,7 @@ setup(
     include_package_data=True,
     package_dir={'mujoco_py': 'mujoco_py'},
     package_data={'mujoco_py': ['generated/*.so']},
+    ext_modules=cythonize(ext_modules),
     install_requires=read_requirements_file('requirements.txt'),
     tests_require=read_requirements_file('requirements.dev.txt'),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
+import os
 from os.path import join, dirname, realpath
 from setuptools import find_packages, setup
+from distutils.command.build import build as DistutilsBuild
 
 
 with open(join("mujoco_py", "version.py")) as version_file:
@@ -19,6 +21,14 @@ for p in packages:
     assert p == 'mujoco_py' or p.startswith('mujoco_py.')
 
 
+class Build(DistutilsBuild):
+    def run(self):
+        os.environ['MUJOCO_PY_FORCE_REBUILD'] = 'True'
+        os.environ['MUJOCO_PY_SKIP_ACTIVATE'] = 'True'
+        import mujoco_py  # noqa: force build
+        DistutilsBuild.run(self)
+
+
 setup(
     name='mujoco-py',
     version=__version__,  # noqa
@@ -27,6 +37,7 @@ setup(
     url='https://github.com/openai/mujoco-py',
     packages=packages,
     include_package_data=True,
+    cmdclass={'build': Build},
     package_dir={'mujoco_py': 'mujoco_py'},
     package_data={'mujoco_py': ['generated/*.so']},
     install_requires=read_requirements_file('requirements.txt'),


### PR DESCRIPTION
This changes the "mujoco-py" package to build/compile at install time, instead of first-run time.

This also gives a flag MUJOCO_PY_FORCE_REBUILD, which will be useful for virtual machine images (like docker containers) where the build-time context is different from the run-time context.