### PR TITLE
Faster method for reading only the depth buffer

### DIFF
--- a/mujoco_py/mjrendercontext.pyx
+++ b/mujoco_py/mjrendercontext.pyx
@@ -176,6 +176,17 @@ cdef class MjRenderContext(object):
         else:
             return rgb_img
 
+    def read_pixels_depth(self, np.ndarray[np.float32_t, mode="c", ndim=2] buffer):
+            ''' Read depth pixels into a preallocated buffer '''
+            cdef mjrRect rect
+            rect.left = 0
+            rect.bottom = 0
+            rect.width = buffer.shape[1]
+            rect.height = buffer.shape[0]
+
+            cdef float[::view.contiguous] buffer_view = buffer.ravel()
+            mjr_readPixels(NULL, &buffer_view[0], rect, &self._con)
+
     def upload_texture(self, int tex_id):
         """ Uploads given texture to the GPU. """
         self.opengl_context.make_context_current()

--- a/mujoco_py/tests/test_opengl_context.py
+++ b/mujoco_py/tests/test_opengl_context.py
@@ -1,4 +1,6 @@
+#!/usr/bin/env python
 import pytest
+import numpy as np
 from mujoco_py import MjSim, load_model_from_xml, MjRenderContext, GlfwContext
 from mujoco_py.tests.utils import compare_imgs
 
@@ -44,3 +46,18 @@ def test_glfw_context():
     compare_imgs(sim.render(201, 205, camera_name="topcam"), 'test_glfw_context.png')
     assert len(sim.render_contexts) == 1
     assert sim.render_contexts[0] is render_context
+
+
+@pytest.mark.requires_rendering
+def test_read_depth_buffer():
+    model = load_model_from_xml(BASIC_MODEL_XML)
+    sim = MjSim(model)
+    sim.forward()
+    ctx = MjRenderContext(sim, offscreen=True, opengl_backend='glfw')
+
+    buf = np.zeros((11, 100), dtype=np.float32)
+    assert buf.sum() == 0, f'{buf.sum()}'
+
+    ctx.render(buf.shape[1], buf.shape[0], 0)
+    ctx.read_pixels_depth(buf)
+    assert buf.sum() != 0, f'{buf.sum()} {buf.max()}'

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (1, 50, 1, 67)
+version_info = (1, 50, 1, 68)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 


### PR DESCRIPTION
I'm experimenting with using these as observation spaces, which means we need a fast-path to getting only depth rendering.

Differences from existing readpixels:

- allows passing a pre-allocated buffer
- skips rendering RGB buffer

tagging @welinder because I think you will point me at the right unit-testing method for verifying pixel-perfect images.