### PR TITLE
Add MacPorts GCC version into the list of supported compilers.

### DIFF
--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -310,7 +310,10 @@ class MacExtensionBuilder(MujocoExtensionBuilder):
             # Known-working versions of GCC on mac
             c_compilers = ['/usr/local/bin/gcc-6',
                            '/usr/local/bin/gcc-7',
-                           '/usr/local/bin/gcc-8']
+                           '/usr/local/bin/gcc-8',
+                           '/opt/local/bin/gcc-mp-6',
+                           '/opt/local/bin/gcc-mp-7',
+                           '/opt/local/bin/gcc-mp-8']
             available_c_compiler = None
             for c_compiler in c_compilers:
                 if distutils.spawn.find_executable(c_compiler) is not None:
@@ -320,7 +323,8 @@ class MacExtensionBuilder(MujocoExtensionBuilder):
                 raise RuntimeError(
                     'Could not find GCC executable.\n\n'
                     'HINT: On OS X, install GCC with '
-                    '`brew install gcc`.')
+                    '`brew install gcc` or'
+                    '`port install gcc`.')
             os.environ['CC'] = available_c_compiler
 
             so_file_path = super()._build_impl()

--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -323,7 +323,7 @@ class MacExtensionBuilder(MujocoExtensionBuilder):
                 raise RuntimeError(
                     'Could not find GCC executable.\n\n'
                     'HINT: On OS X, install GCC with '
-                    '`brew install gcc` or'
+                    '`brew install gcc` or '
                     '`port install gcc`.')
             os.environ['CC'] = available_c_compiler
 


### PR DESCRIPTION
I've got stuck almost for an hour during installation trying to figure out why my gcc doesn't work, just because I haven't noticed that there is a fixed list of supported gcc versions, which is apparently defined just based on brew versions. I'm proposing edit to add MacPorts gcc version as well, I haven't test the `gcc-mp-9`, but all the others seems to work.

I'm using MacPorts for a while and I haven't encountered any problems, so I don't see why to exclude it from the list. 

Other approach could be to actually use system gcc and parse output of `gcc --version` to know if the version is actually supported or not, but that seems like little overkill.