### PR TITLE
Remove unnecessary GL/glext.h include

### DIFF
--- a/mujoco_py/gl/eglshim.c
+++ b/mujoco_py/gl/eglshim.c
@@ -4,7 +4,6 @@
 #include <GL/glew.h>
 #include <GL/gl.h>
 #include <GL/glu.h>
-#include <GL/glext.h>
 
 #include "mujoco.h"
 #include "mjrender.h"


### PR DESCRIPTION
The `GL/glext.h` has some conflicting types with `GL/glew.h`, which breaks the `gl/eglshim.c` and thus also the gpu rendering. At the first glance, the definitions in `GL/glext.h` seem unnecessary, so I think it's ok to remove the include. Please correct me if I'm wrong here.

I don't know exactly what package causes this, but I believe the reason it happens now and not earlier is that mesa go updated on apt from `18.2.2` to `18.2.8` (and unfortunately no earlier versions are available in apt).

Fixes #383 