### PR TITLE
add setup requires so that docker does not error out

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ setup(
     package_dir={'mujoco_py': 'mujoco_py'},
     package_data={'mujoco_py': ['generated/*.so']},
     install_requires=read_requirements_file('requirements.txt'),
+    setup_requires=read_requirements_file('requirements.txt'),
     tests_require=read_requirements_file('requirements.dev.txt'),
 )


### PR DESCRIPTION
While this isn't necessary for `pip install` to work locally, without this line it seems that the return code is `1`.

This can be an issue if, for example, I'm installing from a Dockerfile. In that case, adding a line like
```
RUN  pip install -U 'mujoco-py<2.1,>=2.0
```
halts the building process, saying
```
The command '/bin/bash -c pip install -U 'mujoco-py<2.1,>=2.0'' returned a non-zero code: 1
```

What's odd is that after running `pip install -U 'mujoco-py<2.1,>=2.0` locally, the error code `0`. So it seems this PR is only needed for building from Dockerfile's.

There might be a more elegant solution that I'm not aware of, but I tried
```
RUN pip install -U git+https://github.com/vitchyr/mujoco-py.git@4cd37df2def8417eeaab48e0db561f2091080f9a
```
and this works.