### PR TITLE
Add python_requires and classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,11 @@ setup(
     package_data={'mujoco_py': ['generated/*.so']},
     install_requires=read_requirements_file('requirements.txt'),
     tests_require=read_requirements_file('requirements.dev.txt'),
+    python_requires='>=3.5',
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3 :: Only',
+    ],
 )


### PR DESCRIPTION
`python_requires` helps pip ensure the correct version of this package is installed for the user's running Python version.

`classifiers` help make it clear on https://pypi.org/project/mujoco-py/ which versions are supported.