### PR TITLE
Add option to override the mujoco error callback.

### DIFF
--- a/mujoco_py/tests/test_cymj.py
+++ b/mujoco_py/tests/test_cymj.py
@@ -14,7 +14,7 @@ from mujoco_py import (MjSim, load_model_from_xml,
                        load_model_from_path, MjSimState,
                        ignore_mujoco_warnings,
                        load_model_from_mjb)
-from mujoco_py import const, cymj
+from mujoco_py import const, cymj, functions
 from mujoco_py.tests.utils import compare_imgs
 
 
@@ -332,6 +332,20 @@ def test_mj_warning_raises():
     with pytest.raises(Exception):
         # This should raise an exception due to the mujoco warning callback
         sim.step()
+
+
+def test_mj_error_called():
+    error_message = None
+
+    def error_callback(msg):
+        nonlocal error_message
+        error_message = msg.decode()
+
+    cymj.set_error_callback(error_callback)
+
+    functions.mju_error("error")
+
+    assert error_message == "error"
 
 
 def test_ignore_mujoco_warnings():

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (2, 0, 2, 2)
+version_info = (2, 0, 2, 3)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 


### PR DESCRIPTION
Few extra bits of code to override the error callback.