### PR TITLE
Add pyproject.toml for build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = [
+    "setuptools",
+    "glfw>=1.4.0",
+    "numpy>=1.11",
+    "Cython>=0.27.2",
+    "imageio>=2.1.2",
+    "cffi>=1.10",
+    "lockfile>=0.12.2"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# When updating these, you may need to also update pyproject.toml
 glfw>=1.4.0
 numpy>=1.11
 Cython>=0.27.2


### PR DESCRIPTION
setup.py's build does an actual compilation of mujoco-py, which has dependencies. These are thus build dependencies, not just install dependencies. Right now, oftentimes when doing `pip install mujoco-py`, this build fails and the compilation doesn't occur until actual first runtime import.

PEP518 describes the pyproject.toml file used to declare build dependencies. This adds that file, fixing the behavior to compile mujoco-py during pip install.