### PR TITLE
Travis CI: The sudo tag is now deprecated in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-sudo: required
 language: generic
-dist: trusty
 
 before_install:
 - curl $MUJOCO_FOR_LINUX | tar -xz ./mjkey.txt


### PR DESCRIPTION
A second attempt at #429