### PR TITLE
include pyproject.toml in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include pyproject.toml
 include requirements.txt
 include requirements.dev.txt
 recursive-include mujoco_py *.h *.py *.pyx *.pxd *.pxi *.xml *.c


### PR DESCRIPTION
This should've been included in #439. Ensure the pyproject.toml makes its way into sdist for packaging