### PR TITLE
a small fix

### DIFF
--- a/mujoco_py/mjpid.pyx
+++ b/mujoco_py/mjpid.pyx
@@ -80,7 +80,10 @@ cdef mjtNum c_pid_bias(const mjModel* m, const mjData* d, int id) with gil:
     d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_LAST_ERROR] = error
     d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_DERIVATIVE_ERROR_LAST] = derivative_error
     d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_INTEGRAL_ERROR] = integral_error
-    return fmax(effort_limit_low, fmin(effort_limit_high, f))
+    
+    if effort_limit_low != 0.0 and effort_limit_high != 0.0:
+        f = fmax(effort_limit_low, fmin(effort_limit_high, f))
+    return f
 
 
 def set_pid_control(m, d):

--- a/mujoco_py/mjpid.pyx
+++ b/mujoco_py/mjpid.pyx
@@ -81,7 +81,7 @@ cdef mjtNum c_pid_bias(const mjModel* m, const mjData* d, int id) with gil:
     d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_DERIVATIVE_ERROR_LAST] = derivative_error
     d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_INTEGRAL_ERROR] = integral_error
     
-    if effort_limit_low != 0.0 and effort_limit_high != 0.0:
+    if effort_limit_low != 0.0 or effort_limit_high != 0.0:
         f = fmax(effort_limit_low, fmin(effort_limit_high, f))
     return f
 

--- a/mujoco_py/tests/test_pid.py
+++ b/mujoco_py/tests/test_pid.py
@@ -36,11 +36,11 @@ PID_ACTUATOR = """
 """
 
 P_ONLY_ACTUATOR = """
-	<general ctrlrange='-1 1' gaintype="user" biastype="user" forcerange="-100 100" gainprm="200" joint="hinge" name="a-hinge"/>
+	<general ctrlrange='-1 1' gaintype="user" biastype="user" gainprm="200" joint="hinge" name="a-hinge"/>
 """
 
 POSITION_ACTUATOR = """
-	<position ctrlrange='-1 1' forcerange="-100 100" kp=200 joint="hinge" name="a-hinge"/>
+	<position ctrlrange='-1 1' kp=200 joint="hinge" name="a-hinge"/>
 """
 
 
@@ -87,8 +87,8 @@ def test_mj_proptional_only():
 	sim.data.qpos[0] = sim2.data.qpos[0] = init_pos
 	sim.data.ctrl[0] = sim2.data.ctrl[0] = 0
 
-	for i in range(20):
+	for i in range(2000):
 		print(i, sim.data.qpos[0], sim2.data.qpos[0])
 		sim.step()
 		sim2.step()
-		assert abs(sim.data.qpos[0] - sim2.data.qpos[0]) <= 1e-5, "%d step violates" % i
+		assert abs(sim.data.qpos[0] - sim2.data.qpos[0]) <= 1e-7, "%d step violates" % i

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (2, 0, 2, 7)
+version_info = (2, 0, 2, 8)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 


### PR DESCRIPTION
when actuator_forcerange is not set (or 0), do not apply truncate 

this could cause some undesirable behavior, like: https://github.com/openai/mujoco-py/issues/473

also enforce more strict tests for P_only and position control