### PR TITLE
Add GCC9 and prefer newer over older versions

### DIFF
--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -308,13 +308,17 @@ class MacExtensionBuilder(MujocoExtensionBuilder):
 
     def _build_impl(self):
         if not os.environ.get('CC'):
-            # Known-working versions of GCC on mac
-            c_compilers = ['/usr/local/bin/gcc-6',
-                           '/usr/local/bin/gcc-7',
-                           '/usr/local/bin/gcc-8',
-                           '/opt/local/bin/gcc-mp-6',
-                           '/opt/local/bin/gcc-mp-7',
-                           '/opt/local/bin/gcc-mp-8']
+            # Known-working versions of GCC on mac (prefer latest one)
+            c_compilers = [
+                '/usr/local/bin/gcc-9',
+                '/usr/local/bin/gcc-8',
+                '/usr/local/bin/gcc-7',
+                '/usr/local/bin/gcc-6',
+                '/opt/local/bin/gcc-mp-9',
+                '/opt/local/bin/gcc-mp-8',
+                '/opt/local/bin/gcc-mp-7',
+                '/opt/local/bin/gcc-mp-6',
+            ]
             available_c_compiler = None
             for c_compiler in c_compilers:
                 if distutils.spawn.find_executable(c_compiler) is not None:

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (2, 0, 2, 8)
+version_info = (2, 0, 2, 9)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 


### PR DESCRIPTION
On MacOS Catalina, only the latest `gcc@9` (version 9.2.0_2) works as expected due to some changes in header files.