### PR TITLE
fix offscreen render issue

### DIFF
--- a/mujoco_py/mjrendercontext.pyx
+++ b/mujoco_py/mjrendercontext.pyx
@@ -302,7 +302,7 @@ cdef class MjRenderContext(object):
 
 class MjRenderContextOffscreen(MjRenderContext):
 
-    def __cinit__(self, MjSim sim, int device_id):
+    def __init__(self, MjSim sim, int device_id):
         super().__init__(sim, offscreen=True, device_id=device_id)
 
 class MjRenderContextWindow(MjRenderContext):


### PR DESCRIPTION
This change allows user to render offscreen images without having to spawn an empty mj_viewer window.
Please see [this comment](https://github.com/openai/mujoco-py/issues/510#issuecomment-634916321) in issue #510  