### PR TITLE
Inverse Dynamics Controller

### DIFF
--- a/mujoco_py/mjpid.pyx
+++ b/mujoco_py/mjpid.pyx
@@ -170,7 +170,7 @@ cdef mjtNum c_custom_bias(const mjModel*m, const mjData*d, int id) with gil:
     :param id: actuator ID
     :return: Custom actuator force
     """
-    controller_type = m.actuator_user[id * m.nuser_actuator + IDX_CONTROLLER_TYPE]
+    controller_type = int(m.actuator_user[id * m.nuser_actuator + IDX_CONTROLLER_TYPE])
 
     if controller_type == CONTROLLER_TYPE_INVERSE_DYNAMICS:
         return c_inv_dyn_bias(m, d, id)

--- a/mujoco_py/mjpid.pyx
+++ b/mujoco_py/mjpid.pyx
@@ -142,10 +142,9 @@ cdef mjtNum c_inv_dyn_bias(const mjModel*m, const mjData*d, int id):
 
     # Compute the inverse dynamics and get the joint torque
     mj_inverse(m, d)
-    joint_torque = d.qfrc_inverse[id]
 
     # Write the joint torque
-    f = joint_torque
+    f = d.qfrc_inverse[id]
 
     # Clip joint torque to be within forcerange if specified
     if effort_limit_low != 0.0 or effort_limit_high != 0.0:

--- a/mujoco_py/mjpid.pyx
+++ b/mujoco_py/mjpid.pyx
@@ -1,5 +1,6 @@
 from libc.math cimport fabs, fmax, fmin
 from mujoco_py.generated import const
+import numpy as np
 
 """
   Kp == Kp
@@ -24,19 +25,18 @@ cdef enum USER_DEFINED_ACTUATOR_PARAMS:
     IDX_DERIVATIVE_GAIN_SMOOTHING = 4,
     IDX_ERROR_DEADBAND = 5,
 
-
 cdef enum USER_DEFINED_CONTROLLER_DATA:
     IDX_INTEGRAL_ERROR = 0,
     IDX_LAST_ERROR = 1,
     IDX_DERIVATIVE_ERROR_LAST = 2,
     NUM_USER_DATA_PER_ACT = 3,
 
+cdef int CONTROLLER_TYPE_INVERSE_DYNAMICS = 1,
 
-cdef mjtNum c_zero_gains(const mjModel* m, const mjData* d, int id) with gil:
+cdef mjtNum c_zero_gains(const mjModel*m, const mjData*d, int id) with gil:
     return 0.0
 
-
-cdef mjtNum c_pid_bias(const mjModel* m, const mjData* d, int id) with gil:
+cdef mjtNum c_pid_bias(const mjModel*m, const mjData*d, int id):
     cdef double dt_in_sec = m.opt.timestep
     cdef double error = d.ctrl[id] - d.actuator_length[id]
     cdef int NGAIN = int(const.NGAIN)
@@ -46,7 +46,7 @@ cdef mjtNum c_pid_bias(const mjModel* m, const mjData* d, int id) with gil:
     cdef double integral_max_clamp = m.actuator_gainprm[id * NGAIN + IDX_INTEGRAL_MAX_CLAMP]
     cdef double integral_time_const = m.actuator_gainprm[id * NGAIN + IDX_INTEGRAL_TIME_CONSTANT]
     cdef double derivative_gain_smoothing = \
-        m.actuator_gainprm[id * NGAIN  + IDX_DERIVATIVE_GAIN_SMOOTHING]
+        m.actuator_gainprm[id * NGAIN + IDX_DERIVATIVE_GAIN_SMOOTHING]
     cdef double derivate_time_const = m.actuator_gainprm[id * NGAIN + IDX_DERIVATIVE_TIME_CONSTANT]
 
     cdef double effort_limit_low = m.actuator_forcerange[id * 2]
@@ -65,7 +65,7 @@ cdef mjtNum c_pid_bias(const mjModel* m, const mjData* d, int id) with gil:
     derivative_error_last = d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_DERIVATIVE_ERROR_LAST]
 
     derivative_error = (1.0 - derivative_gain_smoothing) * derivative_error_last + \
-        derivative_gain_smoothing * derivative_error
+                       derivative_gain_smoothing * derivative_error
 
     cdef double integral_error_term = 0.0
     if integral_time_const != 0:
@@ -80,21 +80,114 @@ cdef mjtNum c_pid_bias(const mjModel* m, const mjData* d, int id) with gil:
     d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_LAST_ERROR] = error
     d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_DERIVATIVE_ERROR_LAST] = derivative_error
     d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_INTEGRAL_ERROR] = integral_error
-    
+
     if effort_limit_low != 0.0 or effort_limit_high != 0.0:
         f = fmax(effort_limit_low, fmin(effort_limit_high, f))
     return f
 
+""" 
+   Inverse Dynamics (ID) Controller
+   
+   qacc:               Joint acceleration.
+   qfrc_applied:       Torques applied directly to the joints.
+   xfrc_applied:       Cartesian forces applied directly to bodies.
+   qfrc_actuator:      Torques applied directly to the actuators.
+   Jx'*xfrc_applied:   Joint torque resulting from cartesian forces (xfrc_applied).
+   
+   qfrc_inverse gives the joint torques necessary to achieve a desired joint acceleration (qacc) given 
+   internal and external forces and torques. ID control solves the following torque balance by calling
+   mjinverse(model, data):
+   
+       qfrc_inverse = qfrc_applied + Jx'*xfrc_applied + qfrc_actuator
+   The error in desired joint acceleration is wrapped using a PD controller.
+   To provide a smooth reference signal for the ID controller, an Exponential Moving Average (EMA) is
+   used on the reference control signal (ctrl_ema). 
+   """
+cdef enum USER_DEFINED_ID_ACTUATOR_PARAMS:
+    IDX_ID_PROPORTIONAL_GAIN = 0,
+    IDX_ID_DERIVATIVE_GAIN = 1,
+    IDX_ID_EMA_SMOOTH = 2,
+
+cdef enum USER_DEFINED_ID_CONTROLLER_DATA:
+    IDX_CTRL_REF = 0
+
+cdef mjtNum c_id_bias(const mjModel*m, const mjData*d, int id):
+    cdef int NGAIN = int(const.NGAIN)
+    ctrl_ema = d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_CTRL_REF]
+    ema_smooth = m.actuator_gainprm[id * NGAIN + IDX_ID_EMA_SMOOTH]
+    cdef double effort_limit_low = m.actuator_forcerange[id * 2]
+    cdef double effort_limit_high = m.actuator_forcerange[id * 2 + 1]
+
+    # Apply an Exponential Moving Average (EMA) to desired control
+    ctrl_ema = (ema_smooth * ctrl_ema) + (1 - ema_smooth) * d.ctrl[id]
+
+    qpos_des = ctrl_ema
+    qvel_des = 0
+
+    qpos_error = qpos_des - d.qpos[id]
+    qvel_error = qvel_des - d.qvel[id]
+
+    # PD gains for desired acceleration
+    kp = m.actuator_gainprm[id * NGAIN + IDX_ID_PROPORTIONAL_GAIN]
+    kd = m.actuator_gainprm[id * NGAIN + IDX_ID_DERIVATIVE_GAIN]
+
+    # Set desired acceleration of all DoFs (model.nv) to zero except the target actuator [id]
+    qacc_des = np.zeros(m.nv)
+    qacc_des[id] = kp * qpos_error + kd * qvel_error
+
+    # Set the target forward dyanmics
+    for i in range(m.nv):
+        d.qacc[i] = qacc_des[i]
+
+    # Compute the inverse dynamics and get the joint torque
+    mj_inverse(m, d)
+    joint_torque = d.qfrc_inverse[id]
+
+    # Write the joint torque
+    f = joint_torque
+
+    # Clip joint torque to be within forcerange if specified
+    if effort_limit_low != 0.0 or effort_limit_high != 0.0:
+        f = fmax(effort_limit_low, fmin(effort_limit_high, f))
+
+    # Save smooth control signal in userdata
+    d.userdata[id * NUM_USER_DATA_PER_ACT + IDX_CTRL_REF] = ctrl_ema
+
+    return f
+
+cdef enum USER_DEFINED_ACTUATOR_DATA:
+    IDX_CONTROLLER_TYPE = 0
+    NUM_ACTUATOR_DATA = 1
+
+cdef mjtNum c_custom_bias(const mjModel*m, const mjData*d, int id) with gil:
+    """
+    Switches between PID and ID type custom bias computation based on the
+    defined actuator's actuator_user field.
+    user="1": ID
+    default: PID
+    :param m: mjModel
+    :param d:  mjData
+    :param id: actuator ID
+    :return: Custom actuator force
+    """
+    controller_type = m.actuator_user[id * m.nuser_actuator + IDX_CONTROLLER_TYPE]
+
+    if controller_type == CONTROLLER_TYPE_INVERSE_DYNAMICS:
+        return c_id_bias(m, d, id)
+    return c_pid_bias(m, d, id)
 
 def set_pid_control(m, d):
     global mjcb_act_gain
     global mjcb_act_bias
 
     if m.nuserdata < m.nu * NUM_USER_DATA_PER_ACT:
-        raise Exception('nuserdata is not set large enough to store PID internal states')
+        raise Exception('nuserdata is not set large enough to store PID internal states.')
+
+    if m.nuser_actuator < m.nu * NUM_ACTUATOR_DATA:
+        raise Exception('nuser_actuator is not set large enough to store controller types')
 
     for i in range(m.nuserdata):
         d.userdata[i] = 0.0
 
     mjcb_act_gain = c_zero_gains
-    mjcb_act_bias = c_pid_bias
+    mjcb_act_bias = c_custom_bias

--- a/mujoco_py/tests/test_pid.py
+++ b/mujoco_py/tests/test_pid.py
@@ -5,7 +5,7 @@ from mujoco_py import (MjSim, load_model_from_xml, cymj)
 
 MODEL_XML = """
 <mujoco model="inverted pendulum">
-	<size nuserdata="100"/>
+	<size nuserdata="100" nuser_actuator="{nuser_actuator}"/>
 	<compiler inertiafromgeom="true"/>
 	<default>
 		<joint armature="0" damping="1" limited="true"/>
@@ -35,6 +35,10 @@ PID_ACTUATOR = """
 	<general ctrlrange='-1 1' gaintype="user" biastype="user" forcerange="-100 100" gainprm="200 10 10.0 0.1 0.1 0" joint="hinge" name="a-hinge"/>
 """
 
+INVERSE_DYN_ACTUATOR = """
+	<general ctrlrange='-1 1' gaintype="user" biastype="user" forcerange="-100 100" gainprm="200 0.1 0.97" joint="hinge" name="a-hinge" user="1"/>
+"""
+
 P_ONLY_ACTUATOR = """
 	<general ctrlrange='-1 1' gaintype="user" biastype="user" gainprm="200" joint="hinge" name="a-hinge"/>
 """
@@ -44,51 +48,89 @@ POSITION_ACTUATOR = """
 """
 
 
-"""
-	To enable PID control in the mujoco, please
-	refer to the setting in the PID_ACTUATOR.
-
-	Here we set Kp = 200, Ti = 10, Td = 0.1 (also iClamp = 10.0, dSmooth be 0.1)
-"""
 def test_mj_pid():
-	xml = MODEL_XML.format(actuator=PID_ACTUATOR)
-	model = load_model_from_xml(xml)
-	sim = MjSim(model)
-	cymj.set_pid_control(sim.model, sim.data)
+    """
+    To enable PID control in the mujoco, please
+    refer to the setting in the PID_ACTUATOR.
 
-	# pertubation of pole to be unbalanced
-	init_pos = 0.1 * (random.random() - 0.5)
-	print('init pos', init_pos)
-	sim.data.qpos[0] = init_pos
+    Here we set Kp = 200, Ti = 10, Td = 0.1 (also iClamp = 10.0, dSmooth be 0.1)
+    """
+    xml = MODEL_XML.format(actuator=PID_ACTUATOR, nuser_actuator=1)
+    model = load_model_from_xml(xml)
+    sim = MjSim(model)
+    cymj.set_pid_control(sim.model, sim.data)
 
-	pos = 0.0
-	sim.data.ctrl[0] = pos
-	print('desire position:', pos)
+    # pertubation of pole to be unbalanced
+    init_pos = 0.1 * (random.random() - 0.5)
+    print('init pos', init_pos)
+    sim.data.qpos[0] = init_pos
 
-	for _ in range(100):
-		sim.step()
+    pos = 0.0
+    sim.data.ctrl[0] = pos
+    print('desired position:', pos)
 
-	print('final pos', sim.data.qpos[0])
-	assert abs(sim.data.qpos[0] - pos) < 0.01
+    for _ in range(100):
+        sim.step()
 
-"""
+    print('final pos', sim.data.qpos[0])
+    assert abs(sim.data.qpos[0] - pos) < 0.01
+
+
+def test_mj_proportional_only():
+    """
     check new PID control is backward compatible with  position control
-	when only has Kp term.
-"""
-def test_mj_proptional_only():
-	model = load_model_from_xml(MODEL_XML.format(actuator=P_ONLY_ACTUATOR))
-	sim = MjSim(model)
-	cymj.set_pid_control(sim.model, sim.data)
+    when only has Kp term.
+    """
+    model = load_model_from_xml(MODEL_XML.format(actuator=P_ONLY_ACTUATOR, nuser_actuator=1))
+    sim = MjSim(model)
+    cymj.set_pid_control(sim.model, sim.data)
 
-	model2 = load_model_from_xml(MODEL_XML.format(actuator=POSITION_ACTUATOR))
-	sim2 = MjSim(model2)
+    model2 = load_model_from_xml(MODEL_XML.format(actuator=POSITION_ACTUATOR, nuser_actuator=1))
+    sim2 = MjSim(model2)
 
-	init_pos = 0.1 * (random.random() - 0.5)
-	sim.data.qpos[0] = sim2.data.qpos[0] = init_pos
-	sim.data.ctrl[0] = sim2.data.ctrl[0] = 0
+    init_pos = 0.1 * (random.random() - 0.5)
+    sim.data.qpos[0] = sim2.data.qpos[0] = init_pos
+    sim.data.ctrl[0] = sim2.data.ctrl[0] = 0
 
-	for i in range(2000):
-		print(i, sim.data.qpos[0], sim2.data.qpos[0])
-		sim.step()
-		sim2.step()
-		assert abs(sim.data.qpos[0] - sim2.data.qpos[0]) <= 1e-7, "%d step violates" % i
+    for i in range(2000):
+        print(i, sim.data.qpos[0], sim2.data.qpos[0])
+        sim.step()
+        sim2.step()
+        assert abs(sim.data.qpos[0] - sim2.data.qpos[0]) <= 1e-7, "%d step violates" % i
+
+
+def test_mj_inverse_dyn():
+    """
+    To enable Inverse dynamics control in the mujoco, please
+    refer to the setting in the INVERSE_DYN_ACTUATOR. user param should be set to 1
+
+    Here we set Kp = 200, Td = 0.1 and EMA coefficient to 0.97
+    """
+    xml = MODEL_XML.format(actuator=INVERSE_DYN_ACTUATOR, nuser_actuator=1)
+    model = load_model_from_xml(xml)
+    sim = MjSim(model)
+    cymj.set_pid_control(sim.model, sim.data)
+
+    # pertubation of pole to be unbalanced
+    init_pos = 0.1 * (random.random() - 0.5)
+    print('init pos', init_pos)
+    sim.data.qpos[0] = init_pos
+
+    desired_pos = 0.0
+    sim.data.ctrl[0] = desired_pos
+    print('desired position:', desired_pos)
+
+    for _ in range(100):
+        sim.step()
+
+    print('final pos', sim.data.qpos[0])
+    assert abs(sim.data.qpos[0] - desired_pos) < 0.01
+
+
+def test_mjsize_exception():
+    """nuser_actuator must be set large enough to use custom controllers."""
+    xml = MODEL_XML.format(actuator=INVERSE_DYN_ACTUATOR, nuser_actuator=0)
+    model = load_model_from_xml(xml)
+    sim = MjSim(model)
+    with pytest.raises(Exception):
+        cymj.set_pid_control(sim.model, sim.data)

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (2, 0, 2, 10)
+version_info = (2, 0, 2, 11)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 


### PR DESCRIPTION
Introduce an inverse dynamics (ID) controller. We select between PID vs ID custom controllers based on the actuator_user field that is defined per actuator. `user="1"` would trigger activating an ID controller where the gainprm are interpreted as Kp, Td, ema_smoothing_term, respectively.