### PR TITLE
Add custom key press callback to MjViewer

### DIFF
--- a/mujoco_py/mjviewer.py
+++ b/mujoco_py/mjviewer.py
@@ -131,9 +131,13 @@ class MjViewer(MjViewerBasic):
     ----------
     sim : :class:`.MjSim`
         The simulator to display.
+    custom_key_press_callback : fn(int) -> Any
+        Optional callback for key presses during simulation. At every call to
+        :meth:`.key_callback`, it receives the glfw key that was pressed. This is
+        useful e.g. for implementing custom key bindings outside of mujoco-py during simulation.
     """
 
-    def __init__(self, sim):
+    def __init__(self, sim, custom_key_press_callback=None):
         super().__init__(sim)
 
         self._ncam = sim.model.ncam
@@ -164,6 +168,8 @@ class MjViewer(MjViewerBasic):
         self._time_per_render = 1 / 60.0
         self._hide_overlay = False  # hide the entire overlay.
         self._user_overlay = {}
+
+        self._custom_key_press_callback = custom_key_press_callback
 
     def render(self):
         """
@@ -368,6 +374,10 @@ class MjViewer(MjViewerBasic):
                                     geom_idx, 3] = self.sim.extras[geom_idx]
         elif key in (glfw.KEY_0, glfw.KEY_1, glfw.KEY_2, glfw.KEY_3, glfw.KEY_4):
             self.vopt.geomgroup[key - glfw.KEY_0] ^= 1
+
+        if callable(self._custom_key_press_callback):
+            self._custom_key_press_callback(key)
+
         super().key_callback(window, key, scancode, action, mods)
 
 # Separate Process to save video. This way visualization is

--- a/mujoco_py/tests/test_viewer.py
+++ b/mujoco_py/tests/test_viewer.py
@@ -12,3 +12,11 @@ def test_viewer():
     for _ in range(100):
         sim.step()
         viewer.render()
+
+def test_custom_key_press_callback():
+    model = load_model_from_path("mujoco_py/tests/test.xml")
+    sim = MjSim(model)
+    callback = lambda key: key
+    viewer = MjViewer(sim, callback)
+    assert(viewer._custom_key_press_callback == callback)
+    


### PR DESCRIPTION
This PR adds a custom key press callback to MjViewer so that key presses can be monitored and acted upon outside of mujoco-py e.g. implement control based on the key presses.