### PR TITLE
[bugfix] EMA for the cascaded PID should start with the correct memory value

### DIFF
--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (2, 0, 2, 12)
+version_info = (2, 0, 2, 13)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 


### PR DESCRIPTION
A previous bug introduced a behavior that started the EMA value at 0.0 that caused unintended qvel spikes due to drastic position change. This change allows the EMA to pass the first sample and initialize the EMA memory at the initial sample, avoiding any discontinuity issues.