### PR TITLE
avoid calling glfwTerminate( ) inside callback

### DIFF
--- a/mujoco_py/mjviewer.py
+++ b/mujoco_py/mjviewer.py
@@ -63,8 +63,7 @@ class MjViewerBasic(cymj.MjRenderContextWindow):
         if action == glfw.RELEASE and key == glfw.KEY_ESCAPE:
             print("Pressed ESC")
             print("Quitting.")
-            glfw.terminate()
-            sys.exit(0)
+            glfw.set_window_should_close(window, 1)
 
     def _cursor_pos_callback(self, window, xpos, ypos):
         if not (self._button_left_pressed or self._button_right_pressed):


### PR DESCRIPTION
[GLFW guidelines](https://www.glfw.org/docs/3.3/intro_guide.html#reentrancy) say `glfwTerminate()` should not be called inside an event callback, since it is not reentrant. This fixes segfault when closing the `MjViewer` window by pressing ESC.