### PR TITLE
Detect the correct nvidia lib path for modern ubuntu systems

### DIFF
--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -31,6 +31,11 @@ def get_nvidia_lib_dir():
     docker_path = '/usr/local/nvidia/lib64'
     if exists(docker_path):
         return docker_path
+
+    nvidia_path = '/usr/lib/nvidia'
+    if exists(nvidia_path):
+        return nvidia_path
+
     paths = glob.glob('/usr/lib/nvidia-[0-9][0-9][0-9]')
     paths = sorted(paths)
     if len(paths) == 0:


### PR DESCRIPTION
I am glad to see that this package is still maintained (and should be), given that `mujoco-py` is very widely used in the research community, and we are expecting **a new release** for mujuco 2.1 support as #640 has been finally merged. I think this is another patch that would be very nice to include towards the next release.

To enable GPU extensions, previously either `/usr/local/nvidia/lib64` (for dockers) or `/usr/lib/nvidia-\d\d\d` needed to exist, but in most of the modern debian and ubuntu systems, the nvidia libraries are **actually installed** under the path `/usr/lib/nvidia`.

The commit corrects the path to nvidia library path so that GPU extensions can be installed without any hacky workarounds, to name a few: #583 #383 #408, where users had to do the following hack:
```
sudo mkdir -p /usr/lib/nvidia-000
```


