### PR TITLE
Fix gym rewards by automatically evaluating cfrc_ext

### DIFF
--- a/mujoco_py/mjsim.pyx
+++ b/mujoco_py/mjsim.pyx
@@ -127,6 +127,7 @@ cdef class MjSim(object):
             for _ in range(self.nsubsteps):
                 self.substep_callback()
                 mj_step(self.model.ptr, self.data.ptr)
+            mj_rnePostConstraint(self.model.ptr, self.data.ptr)
 
     def render(self, width=None, height=None, *, camera_name=None, depth=False,
                mode='offscreen', device_id=-1, segmentation=False):


### PR DESCRIPTION
This change should prevent openai/gym from producing incorrect results when mujoco 2 is used (which many people are doing in practice).

This PR replaces PR #594 (also by me) but is from my fork (instead of @AlexanderGri's fork), so that I can rebase it for the CI.