### PR TITLE
Add environment variable MUJOCO_PY_FORCE_GPU

### DIFF
--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -72,8 +72,11 @@ The easy solution is to `import mujoco_py` _before_ `import glfw`.
         Builder = MacExtensionBuilder
     elif sys.platform == 'linux':
         _ensure_set_env_var("LD_LIBRARY_PATH", lib_path)
+ 
         if os.getenv('MUJOCO_PY_FORCE_CPU') is None and get_nvidia_lib_dir() is not None:
             _ensure_set_env_var("LD_LIBRARY_PATH", get_nvidia_lib_dir())
+            Builder = LinuxGPUExtensionBuilder
+        elif os.getenv('MUJOCO_PY_FORCE_GPU') is not None:
             Builder = LinuxGPUExtensionBuilder
         else:
             Builder = LinuxCPUExtensionBuilder


### PR DESCRIPTION
Currently I cannot find a way to show custom nvidia drive files for mujoco_py. hence I am suggesting to add this environment variable to force gpu as a failsafe measure to run in clusters.