### PR TITLE
add build support for `Cython` versions >=3 

### DIFF
--- a/mujoco_py/builder.py
+++ b/mujoco_py/builder.py
@@ -1,3 +1,4 @@
+import cython
 import distutils
 import glob
 import os
@@ -236,7 +237,10 @@ class MujocoExtensionBuilder():
             "script_name": None,
             "script_args": ["build_ext"]
         })
-        dist.ext_modules = cythonize([self.extension])
+        if cython.__version__ < "3.0.0":
+            dist.ext_modules = cythonize([self.extension])
+        else:
+            dist.ext_modules = cythonize([self.extension], compiler_directives={'legacy_implicit_noexcept': True})
         dist.include_dirs = []
         dist.cmdclass = {'build_ext': custom_build_ext}
         build = dist.get_command_obj('build')

--- a/mujoco_py/version.py
+++ b/mujoco_py/version.py
@@ -1,6 +1,6 @@
 __all__ = ['__version__', 'get_version']
 
-version_info = (2, 1, 2, 14)
+version_info = (2, 1, 2, 15)
 # format:
 # ('mujoco_major', 'mujoco_minor', 'mujoco_py_major', 'mujoco_py_minor')
 


### PR DESCRIPTION
Updates the build system to support `Cython>=3.0.0` and `python>=3.13`




@logankilpatrick @nknj @tananaev @jabbany @stevenheidel 
can you make a small new release (2.1.2.15) with this simple PR

We use this old-version of library for reproducibility of RL experiments in [Gymnasium](https://gymnasium.farama.org/) & [Gymnasium-Robotics](https://robotics.farama.org/)

Thanks!

 